### PR TITLE
feat(faucet): deploy USDCFaucet so any user can mint test USDC

### DIFF
--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { useAccount, useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 import { ConnectButtonClient } from "./connect-button-client";
 import { cn } from "@/lib/utils";
-import { PROPVERA_CONTRACT_ADDRESS, PROPVERA_ABI, MOCK_USDC_ADDRESS, MOCK_USDC_ABI } from "@/lib/contracts";
+import { PROPVERA_CONTRACT_ADDRESS, PROPVERA_ABI, MOCK_USDC_ADDRESS, MOCK_USDC_ABI, USDC_FAUCET_ADDRESS, USDC_FAUCET_ABI } from "@/lib/contracts";
 import { useEffect, useState } from "react";
 
 // ── Icons (inline SVG — no extra deps) ──────────────────────────────────────
@@ -82,7 +82,7 @@ export function Navbar() {
 
   const handleMintUSDC = () => {
     if (!address) return;
-    writeContract({ address: MOCK_USDC_ADDRESS, abi: MOCK_USDC_ABI, functionName: "mint", args: [address, 10000n] });
+    writeContract({ address: USDC_FAUCET_ADDRESS, abi: USDC_FAUCET_ABI, functionName: "drip" });
   };
 
   const isOwner = mounted && address && contractOwner

--- a/frontend/lib/abis/faucet.ts
+++ b/frontend/lib/abis/faucet.ts
@@ -1,0 +1,93 @@
+// ABI for USDCFaucet contract
+export const USDC_FAUCET_ABI = [
+  {
+    name: "drip",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    name: "dripTo",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "recipient", type: "address" }],
+    outputs: [],
+  },
+  {
+    name: "canDrip",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "user", type: "address" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    name: "cooldownRemaining",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "user", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "dripAmount",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "cooldown",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "lastDrip",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "usdc",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    name: "setDripAmount",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "newAmount", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    name: "setCooldown",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "newCooldown", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    name: "ownerDrip",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "recipient", type: "address" },
+      { name: "amount",    type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    name: "Dripped",
+    type: "event",
+    inputs: [
+      { name: "recipient",   type: "address", indexed: true  },
+      { name: "amountInEth", type: "uint256", indexed: false },
+    ],
+  },
+  { name: "ZeroAddress",                   type: "error", inputs: [] },
+  { name: "CooldownNotElapsed",            type: "error", inputs: [{ name: "secondsRemaining", type: "uint256" }] },
+] as const;

--- a/frontend/lib/contracts.ts
+++ b/frontend/lib/contracts.ts
@@ -2,18 +2,20 @@
 import { PROPVERA_ABI } from "./abis/propvera";
 import { MOCKUSDC_ABI } from "./abis/mockusdc";
 import { FRACTIONAL_TOKEN_ABI } from "./abis/fractional";
+import { USDC_FAUCET_ABI } from "./abis/faucet";
 
 // Contract Addresses - exported with exact names for imports
 export const PROPVERA_CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_PROPVERA_ADDRESS as `0x${string}`;
 export const PROPVERA_FRACTIONAL_TOKEN_ADDRESS = process.env.NEXT_PUBLIC_FRACTIONAL_TOKEN_ADDRESS as `0x${string}`;
 export const MOCK_USDC_ADDRESS = process.env.NEXT_PUBLIC_USDC_ADDRESS as `0x${string}`;
-
+export const USDC_FAUCET_ADDRESS = process.env.NEXT_PUBLIC_FAUCET_ADDRESS as `0x${string}`;
 export const CHAIN_ID = 420420417;
 
 // Re-export ABIs with proper names
 export { PROPVERA_ABI };
 export { MOCKUSDC_ABI as MOCK_USDC_ABI };
 export { FRACTIONAL_TOKEN_ABI as PROPVERA_FRACTIONAL_TOKEN_ABI };
+export { USDC_FAUCET_ABI };
 
 // Error message mapping for contract reverts
 export const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
@@ -30,6 +32,7 @@ export const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
   NotBuyer: "You are not the buyer of this asset",
   AssetNotFractionalized: "This asset is not fractionalized",
   ListingNotActive: "This listing is no longer active",
+  CooldownNotElapsed: "Please wait before requesting more USDC",
 };
 
 // Parse error message from contract revert
@@ -44,7 +47,6 @@ export function parseContractError(error: unknown): string {
     // Return raw error if no match
     return error;
   }
-
   if (error instanceof Error) {
     const message = error.message;
     for (const [errorName, msg] of Object.entries(CONTRACT_ERROR_MESSAGES)) {
@@ -54,6 +56,5 @@ export function parseContractError(error: unknown): string {
     }
     return message;
   }
-
   return "An unknown error occurred";
 }

--- a/smart-contract/contracts/mocks/USDCFaucet.sol
+++ b/smart-contract/contracts/mocks/USDCFaucet.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+interface IMockUSDC {
+    function mint(address to, uint256 amountInEth) external;
+}
+
+/// @title  USDCFaucet
+/// @notice Public faucet — anyone can call drip() to receive test USDC once
+///         per cooldown window. Requires this contract to be whitelisted as a
+///         minter on MockUSDC (call usdc.setMinter(faucet, true) after deploy).
+///
+/// @dev    Rate-limiting prevents one address draining all supply.
+///         Owner can adjust drip amount and cooldown at any time.
+contract USDCFaucet is Ownable(msg.sender) {
+
+    // ── State ─────────────────────────────────────────────────────────────────
+
+    IMockUSDC public immutable usdc;
+
+    /// @notice Amount minted per drip in whole USDC units (e.g. 10000 = 10,000 USDC)
+    uint256 public dripAmount = 10_000;
+
+    /// @notice Seconds a user must wait between drips (default 24 hours)
+    uint256 public cooldown = 24 hours;
+
+    /// @notice Last drip timestamp per address
+    mapping(address => uint256) public lastDrip;
+
+    // ── Errors ────────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error CooldownNotElapsed(uint256 secondsRemaining);
+
+    // ── Events ────────────────────────────────────────────────────────────────
+
+    event Dripped(address indexed recipient, uint256 amountInEth);
+    event DripAmountUpdated(uint256 newAmount);
+    event CooldownUpdated(uint256 newCooldown);
+
+    // ── Constructor ───────────────────────────────────────────────────────────
+
+    constructor(address _usdc) {
+        if (_usdc == address(0)) revert ZeroAddress();
+        usdc = IMockUSDC(_usdc);
+    }
+
+    // ── Public ────────────────────────────────────────────────────────────────
+
+    /// @notice Drip test USDC to the caller.
+    /// @dev    Reverts if cooldown has not elapsed since last drip.
+    function drip() external {
+        uint256 elapsed = block.timestamp - lastDrip[msg.sender];
+        if (elapsed < cooldown) {
+            revert CooldownNotElapsed(cooldown - elapsed);
+        }
+        lastDrip[msg.sender] = block.timestamp;
+        usdc.mint(msg.sender, dripAmount);
+        emit Dripped(msg.sender, dripAmount);
+    }
+
+    /// @notice Drip to a specific recipient (useful for frontend tx on behalf).
+    function dripTo(address recipient) external {
+        if (recipient == address(0)) revert ZeroAddress();
+        uint256 elapsed = block.timestamp - lastDrip[recipient];
+        if (elapsed < cooldown) {
+            revert CooldownNotElapsed(cooldown - elapsed);
+        }
+        lastDrip[recipient] = block.timestamp;
+        usdc.mint(recipient, dripAmount);
+        emit Dripped(recipient, dripAmount);
+    }
+
+    /// @notice Seconds remaining until address can drip again. Returns 0 if ready.
+    function cooldownRemaining(address user) external view returns (uint256) {
+        uint256 elapsed = block.timestamp - lastDrip[user];
+        if (elapsed >= cooldown) return 0;
+        return cooldown - elapsed;
+    }
+
+    /// @notice True if user can drip right now.
+    function canDrip(address user) external view returns (bool) {
+        return (block.timestamp - lastDrip[user]) >= cooldown;
+    }
+
+    // ── Owner ─────────────────────────────────────────────────────────────────
+
+    /// @notice Update drip amount (whole USDC units).
+    function setDripAmount(uint256 newAmount) external onlyOwner {
+        dripAmount = newAmount;
+        emit DripAmountUpdated(newAmount);
+    }
+
+    /// @notice Update cooldown window in seconds.
+    function setCooldown(uint256 newCooldown) external onlyOwner {
+        cooldown = newCooldown;
+        emit CooldownUpdated(newCooldown);
+    }
+
+    /// @notice Owner can bypass cooldown to drip directly to any address.
+    function ownerDrip(address recipient, uint256 amount) external onlyOwner {
+        if (recipient == address(0)) revert ZeroAddress();
+        usdc.mint(recipient, amount);
+        emit Dripped(recipient, amount);
+    }
+}

--- a/smart-contract/scripts/deployFaucet.js
+++ b/smart-contract/scripts/deployFaucet.js
@@ -1,0 +1,53 @@
+// scripts/deployFaucet.js
+// Run AFTER the main deploy script.
+// Deploys USDCFaucet, whitelists it as a minter on MockUSDC.
+//
+// Usage:
+//   npx hardhat run scripts/deployFaucet.js --network polkadotTestnet
+
+const { ethers } = require("hardhat");
+
+// ── CONFIG ────────────────────────────────────────────────────────────────────
+// Paste your already-deployed MockUSDC address here:
+const MOCK_USDC_ADDRESS = "0xAdf4d9B286D4c757d5aAce5EE544318F895A0E06";
+
+// Drip amount in whole USDC (10,000 USDC per drip)
+const DRIP_AMOUNT = 10_000n;
+
+// Cooldown in seconds — set to 0 for testnet (no waiting)
+const COOLDOWN_SECONDS = 0n;
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying USDCFaucet with:", deployer.address);
+
+  // 1. Deploy faucet
+  const Faucet = await ethers.getContractFactory("USDCFaucet");
+  const faucet = await Faucet.deploy(MOCK_USDC_ADDRESS);
+  await faucet.waitForDeployment();
+  const faucetAddress = await faucet.getAddress();
+  console.log("USDCFaucet deployed to:", faucetAddress);
+
+  // 2. Set cooldown to 0 for testnet (users can drip any time)
+  if (COOLDOWN_SECONDS === 0n) {
+    await faucet.setCooldown(0n);
+    console.log("Cooldown set to 0 (testnet mode — no waiting)");
+  }
+
+  // 3. Set drip amount
+  await faucet.setDripAmount(DRIP_AMOUNT);
+  console.log(`Drip amount set to ${DRIP_AMOUNT} USDC per call`);
+
+  // 4. Whitelist faucet as a minter on MockUSDC
+  const usdc = await ethers.getContractAt("MockUSDC", MOCK_USDC_ADDRESS);
+  await usdc.setMinter(faucetAddress, true);
+  console.log("Faucet whitelisted as minter on MockUSDC ✓");
+
+  console.log("\n──────────────────────────────────────────");
+  console.log("USDCFaucet address:", faucetAddress);
+  console.log("Add this to your .env.local and Vercel:");
+  console.log(`NEXT_PUBLIC_FAUCET_ADDRESS=${faucetAddress}`);
+  console.log("──────────────────────────────────────────\n");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
- Add USDCFaucet.sol — minter-whitelisted contract that calls MockUSDC.mint() on behalf of users; cooldown=0 for testnet, adjustable by owner
- Add deployFaucet.js — deploys faucet, sets cooldown to 0, whitelists as minter
- Add frontend/lib/abis/faucet.ts — full faucet ABI
- Update contracts.ts — add USDC_FAUCET_ADDRESS + USDC_FAUCET_ABI exports
- Update navbar.tsx — Get USDC button now calls faucet.drip() instead of usdc.mint() directly, fixing the NotMinter revert for regular users
closes #18 