### PR TITLE
 fix: fractional share USDC approval truncation + admin mobile input

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -143,8 +143,8 @@ export default function AdminPage() {
                 {verified.map((a: any) => {
                   const meta = parseTokenURI(a.tokenURI || "");
                   const tid = a.tokenId.toString();
-                  const totalTokens = fracTokens[tid] || "100";
-                  const ppt = Number(totalTokens) > 0 ? (Number(a.priceInEth) / Number(totalTokens)).toFixed(4) : "0";
+                  const totalTokens = fracTokens[tid] || "";
+                  const ppt = Number(totalTokens) > 0 ? (Number(a.priceInEth) / Number(totalTokens)).toFixed(4) : "—";
                   const tokenId = BigInt(tid) as bigint;
                   return (
                     <div key={tid} className="p-4 border border-border rounded-lg">
@@ -158,16 +158,33 @@ export default function AdminPage() {
                       <div className="flex gap-3 items-end">
                         <div className="flex-1">
                           <label className="text-xs text-muted block mb-1">Total PVF tokens to issue</label>
-                          <input type="number" value={totalTokens}
-                            onChange={e => setFracTokens(p => ({ ...p, [tid]: e.target.value }))}
-                            className="w-full px-3 py-2 border border-border rounded-md text-sm bg-background" placeholder="100" />
+                          <div className="flex items-center border border-border rounded-md overflow-hidden bg-background">
+                            <button
+                              type="button"
+                              className="px-3 py-2 text-sm font-bold hover:bg-muted/20 select-none"
+                              onClick={() => setFracTokens(p => ({ ...p, [tid]: String(Math.max(1, Number(p[tid] || "0") - 1)) }))}
+                            >−</button>
+                            <input
+                              type="number"
+                              min="1"
+                              value={fracTokens[tid] ?? ""}
+                              onChange={e => setFracTokens(p => ({ ...p, [tid]: e.target.value }))}
+                              className="flex-1 px-2 py-2 text-sm text-center bg-transparent outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                              placeholder="e.g. 100"
+                            />
+                            <button
+                              type="button"
+                              className="px-3 py-2 text-sm font-bold hover:bg-muted/20 select-none"
+                              onClick={() => setFracTokens(p => ({ ...p, [tid]: String(Number(p[tid] || "0") + 1) }))}
+                            >+</button>
+                          </div>
                         </div>
                         <div className="flex-1">
                           <label className="text-xs text-muted block mb-1">Price per token (USDC)</label>
                           <input readOnly value={ppt} className="w-full px-3 py-2 border border-border rounded-md text-sm bg-muted/20" />
                         </div>
-                        <Button size="sm" disabled={isPending}
-                          onClick={() => { writeContract({ address: PROPVERA_CONTRACT_ADDRESS, abi: PROPVERA_ABI, functionName: "createFractionalAsset", args: [tokenId, BigInt(totalTokens || "100")] }); setTxStatus("Fractionalizing..."); }}>
+                        <Button size="sm" disabled={isPending || !fracTokens[tid] || Number(fracTokens[tid]) < 1}
+                          onClick={() => { writeContract({ address: PROPVERA_CONTRACT_ADDRESS, abi: PROPVERA_ABI, functionName: "createFractionalAsset", args: [tokenId, BigInt(fracTokens[tid] || "0")] }); setTxStatus("Fractionalizing..."); }}>
                           Fractionalize
                         </Button>
                       </div>

--- a/frontend/app/asset/[id]/page.tsx
+++ b/frontend/app/asset/[id]/page.tsx
@@ -42,6 +42,13 @@ export default function AssetPage({ params }: { params: Promise<{ id: string }> 
     address: MOCK_USDC_ADDRESS, abi: MOCK_USDC_ABI, functionName: "allowance",
     args: address ? [address, PROPVERA_CONTRACT_ADDRESS] : undefined, query: { enabled: !!address },
   });
+  // Read raw pricePerToken directly from storage (USDC wei, 6 decimals, no integer division).
+  // getAssetDisplayInfo truncates decimals via usdcFromWei (e.g. 60.1 USDC -> 60),
+  // so approvals derived from it are too low and the tx fails.
+  const { data: rawFractionalData } = useReadContract({
+    address: PROPVERA_CONTRACT_ADDRESS, abi: PROPVERA_ABI, functionName: "fractionalAssets",
+    args: [tokenId],
+  });
   const { data: usdcBalance } = useReadContract({
     address: MOCK_USDC_ADDRESS, abi: MOCK_USDC_ABI, functionName: "balanceOf",
     args: address ? [address] : undefined, query: { enabled: !!address },
@@ -71,8 +78,15 @@ export default function AssetPage({ params }: { params: Promise<{ id: string }> 
   const balance = (usdcBalance as bigint) || 0n;
   const pct = a.isFractionalized && a.totalFractionalTokens > 0
     ? Math.round(((Number(a.totalFractionalTokens) - Number(a.remainingFractionalTokens)) / Number(a.totalFractionalTokens)) * 100) : 0;
+  // Use raw pricePerToken (already in USDC wei) if available, otherwise fall back to display value * 1e6
+  const rawPricePerTokenWei: bigint = rawFractionalData
+    ? (rawFractionalData as any).pricePerToken ?? (rawFractionalData as any)[2] ?? 0n
+    : 0n;
   const fracCost = fracAmt ? BigInt(fracAmt) * BigInt(a.pricePerFractionalTokenInEth.toString()) : 0n;
-  const fracCostWei = fracCost * 1_000_000n;
+  // fracCostWei uses the exact on-chain amount to avoid truncation-caused under-approvals
+  const fracCostWei = fracAmt && rawPricePerTokenWei > 0n
+    ? BigInt(fracAmt) * rawPricePerTokenWei
+    : fracCost * 1_000_000n;
   const isBuyer = address && a.currentBuyer?.toLowerCase() === address.toLowerCase();
 
   const approveUSDC = (amount: bigint) => {


### PR DESCRIPTION
### Problem 1 — USDC approval too low when buying fractional shares

On the asset page, the USDC approval amount was derived from `pricePerFractionalTokenInEth` returned by `getAssetDisplayInfo`. This value goes through `usdcFromWei` (integer division by `1_000_000`) before being returned, truncating any sub-cent decimals.

Example: a token priced at `60_100_000` USDC wei (60.1 USDC) comes back as `60`. The approval was calculated as `60 * 1_000_000 = 60_000_000` — short by `100_000` units — causing `buyFractionalAsset` to fail with an insufficient allowance error.

```ts
// BEFORE — truncated display value used for approval
const fracCost = BigInt(fracAmt) * BigInt(a.pricePerFractionalTokenInEth.toString());
const fracCostWei = fracCost * 1_000_000n; // 60 * 1_000_000 = 60_000_000 ❌
```

**Fix:** Added a `useReadContract` call to read `fractionalAssets(tokenId)` directly from the public storage mapping. This returns `pricePerToken` in raw USDC wei with no integer division, giving the exact amount the contract will deduct.

```ts
// AFTER — exact on-chain value used for approval
const { data: rawFractionalData } = useReadContract({
  functionName: "fractionalAssets",
  args: [tokenId],
});
const rawPricePerTokenWei = (rawFractionalData as any).pricePerToken;
const fracCostWei = BigInt(fracAmt) * rawPricePerTokenWei; // 60_100_000 exact ✅
```

The displayed total cost (`fracCost`) is unchanged — only the approval amount is affected.

---

### Problem 2 — Admin can't change token count input on mobile

The "Total PVF tokens to issue" input on the admin fractionalize panel was pre-filled with a default value of `"100"` via state initialisation. On mobile, number inputs with a pre-filled value don't allow the user to delete or overwrite the existing number, so admins were stuck with `100` and couldn't change it. On desktop the native browser spin arrows worked but were inconsistent.

**Fix:**
- Removed the hardcoded `"100"` default — input now starts empty with a placeholder
- Added explicit **−** and **+** stepper buttons on either side of the input that work reliably on both mobile and desktop
- Native number spin arrows hidden to avoid duplicate controls
- "Fractionalize" button disabled until a valid number ≥ 1 is entered
- Price-per-token preview shows `"—"` when the field is empty instead of silently calculating from `100`

---

### Files changed

- `frontend/app/asset/[id]/page.tsx` — fix 1
- `frontend/app/admin/page.tsx` — fix 2

### Testing

**Fix 1:**
- Fractionalize an asset where the total price is not evenly divisible by the token count (produces a non-round price per token)
- Buy fractional shares — approval and purchase should both complete without a failed tx

**Fix 2:**
- Open the admin panel on a mobile device
- Navigate to the Fractionalize section — input should be empty and editable
- Tap − and + to increment/decrement the token count
- Verify the Fractionalize button stays disabled until a number is entered

 closes #26 